### PR TITLE
change dependabot to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
for some reason dependabot send pull requests with updates on this repo even if there isn't dependabot.yml so I'm just going to make sure it doesn't do that more often than once a month by properly configuring it